### PR TITLE
Updated setWindowSize() to use Qt::WindowMaximized

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -83,8 +83,7 @@ QRectF MainWindow::getScreenSize()
 
 void MainWindow::setWindowSize()
 {
-	QRectF screenSize = getScreenSize();
-	resize(screenSize.width(), screenSize.height());
+    this->setWindowState(Qt::WindowMaximized);
 }
 
 void MainWindow::uncheckAllExcept(QAction* action)


### PR DESCRIPTION
The old method would create a window larger than the actual usable screenspace, meaning it didn't consider menubars etc.